### PR TITLE
Support any node version greater than 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "The Sails Company",
   "license": "MIT",
   "engines": {
-    "node": "^6.0"
+    "node": ">=6.0"
   },
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",


### PR DESCRIPTION
Fix to support any node version greater than 6. The carat was only supporting any minor version of node 6. 

https://semver.npmjs.com has a nice visual demonstration to see what versions you are supporting.