### PR TITLE
Check for content-type header in `sendHttpRequest`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,10 +2,10 @@
   //   ╔═╗╔═╗╦  ╦╔╗╔╔╦╗┬─┐┌─┐
   //   ║╣ ╚═╗║  ║║║║ ║ ├┬┘│
   //  o╚═╝╚═╝╩═╝╩╝╚╝ ╩ ┴└─└─┘
-  // A set of basic conventions (similar to .jshintrc) for use within any
-  // arbitrary JavaScript / Node.js package -- inside or outside Sails.js.
-  // For the master copy of this file, see the `.eslintrc` template file in
-  // the `sails-generate` package (https://www.npmjs.com/package/sails-generate.)
+  // A set of basic conventions for use within any arbitrary Node.js package --
+  // inside or outside the Sails framework.  For the master copy of this file,
+  // see the `.eslintrc` template file in the `sails-generate` package
+  // (https://www.npmjs.com/package/sails-generate.)
   // Designed for ESLint v4.
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // For more information about any of the rules below, check out the relevant
@@ -19,8 +19,7 @@
   },
 
   "parserOptions": {
-    "ecmaVersion": 5
-    // ^^This can be changed to `8` if this package doesn't need to support <= Node v6.
+    "ecmaVersion": 8
   },
 
   "globals": {
@@ -29,10 +28,11 @@
   },
 
   "rules": {
+    "block-scoped-var":             ["error"],
     "callback-return":              ["error", ["done", "proceed", "next", "onwards", "callback", "cb"]],
     "camelcase":                    ["warn", {"properties": "always"}],
     "comma-style":                  ["warn", "last"],
-    "curly":                        ["error"],
+    "curly":                        ["warn"],
     "eqeqeq":                       ["error", "always"],
     "eol-last":                     ["warn"],
     "handle-callback-err":          ["error"],
@@ -62,8 +62,9 @@
     "no-unused-vars":               ["warn", {"caughtErrors":"all", "caughtErrorsIgnorePattern": "^unused($|[A-Z].*$)", "argsIgnorePattern": "^unused($|[A-Z].*$)", "varsIgnorePattern": "^unused($|[A-Z].*$)" }],
     "no-use-before-define":         ["error", {"functions":false}],
     "one-var":                      ["warn", "never"],
+    "prefer-arrow-callback":        ["warn", {"allowNamedFunctions":false}],
     "quotes":                       ["warn", "single", {"avoidEscape":false, "allowTemplateLiterals":true}],
-    "semi":                         ["error", "always"],
+    "semi":                         ["warn", "always"],
     "semi-spacing":                 ["warn", {"before":false, "after":true}],
     "semi-style":                   ["warn", "last"]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 .tmp
 npm-debug.log
 package-lock.json
+package-lock.*
 .waterline
 .node_history
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ test_script:
   - node --version
   - npm --version
   # Run the actual tests.
-  - npm test
+  - npm run custom-tests
 
 
 # Don't actually build.

--- a/lib/get-stream.js
+++ b/lib/get-stream.js
@@ -114,13 +114,13 @@ module.exports = {
 
     // Bind a no-op handler for the `error` event to prevent it from crashing the process if it fires.
     // (userland code can still bind and use its own error events).
-    mikealStream.on('error', function noop (unusedErr) { /*… no-op …*/ });//œ
+    mikealStream.on('error', (unusedErr)=>{ /*… no-op …*/ });//œ
     // ^ Since event handlers are garbage collected when the event emitter is itself gc()'d, it is safe
     // for us to bind this event handler here.
 
     // Also bind a one-time error handler specifically to catch a few specific errors that can
     // occur up-front.
-    mikealStream.once('error', function (err) {
+    mikealStream.once('error', (err)=>{
       // console.error('passthrough stream got its first error:', err);
 
       // When receiving subsequent read errors on this Readable stream after
@@ -151,11 +151,11 @@ module.exports = {
     // > also prevents the "cannot pipe after bytes have already been sent"
     // > problem.
     var passThrough = new PassThrough();
-    passThrough.on('error', function noop (unusedErr) { /*… no-op …*/ });//œ
+    passThrough.on('error', (unusedErr)=>{ /*… no-op …*/ });//œ
 
     mikealStream.pipe(passThrough);
 
-    mikealStream.once('response', function(httpIncomingMessage) {
+    mikealStream.once('response', (httpIncomingMessage)=>{
       // console.log('mikeal stream emitted "response" event', httpIncomingMessage);
 
       // If the status code of the response is not in the 2xx range, then

--- a/lib/send-http-request.js
+++ b/lib/send-http-request.js
@@ -115,6 +115,16 @@ module.exports = {
     // Ensure method is upper-cased.
     inputs.method = inputs.method.toUpperCase();
 
+    // Check for a `content-type` (case-insensitive) header
+    if(!_.contains(['GET','HEAD','OPTIONS'], inputs.method) && inputs.headers) {
+      for (let headerName in inputs.headers) {
+        // If we found one, and it's anything but 'application-json', freak out.
+        if(headerName.toLowerCase() === 'content-type' && inputs.headers[headerName] !== 'application-json') {
+          throw new Error('Instead of a header for that `content-type`, please speficy an `encType`, and the appropriate headers will be set automatically.');
+        }
+      }
+    }
+
 
     // Resolve the fully-qualified destination URL.
     // (remember: this also ensures that this is a fully qualified URL, including the protocol)

--- a/lib/send-http-request.js
+++ b/lib/send-http-request.js
@@ -160,7 +160,7 @@ module.exports = {
     if (!_.isUndefined(inputs.body)) {
 
       // Determine if the provided body data is a dictionary (used below)
-      var isProvidedBodyDataDictionary = _.isObject(inputs.body) && !_.isArray(inputs.body) && !_.isFunction(inputs.body);
+      let isProvidedBodyDataDictionary = _.isObject(inputs.body) && !_.isArray(inputs.body) && !_.isFunction(inputs.body);
 
       if(isProvidedBodyDataDictionary || _.isArray(inputs.body)) {
         inputs.body = rttc.coerce('json', inputs.body);
@@ -235,32 +235,30 @@ module.exports = {
     _.extend(requestOpts.headers, inputs.headers||{});
 
     // And send the request using the options dictionary constructed above.
-    request(requestOpts, function gotResponse(err, httpResponse) {
-      try {
-        // The request failed (disconnected from internet?  server down?)
-        // Return the unknown error through the `requestFailed` exit.
-        if (err) {
-          return exits.requestFailed(err);
-        }
+    request(requestOpts, (err, httpResponse)=>{
 
-        // --•
-        // Otherwise, we'll build a normalized server response.
-        //
-        // > Regardless of the status code sent in the response, we'll
-        // > use this dictionary as our output when we exit below.
-        var serverRes = {
-          statusCode: httpResponse.statusCode,
-          headers: httpResponse.headers || {},
-          body: httpResponse.body || ''
-        };
+      // The request failed (disconnected from internet?  server down?)
+      // Return the unknown error through the `requestFailed` exit.
+      if (err) {
+        return exits.requestFailed(err);
+      }
 
-        // If the status code of the response is not in the 2xx range, then
-        // return the server response dictionary through the `non2xxResponse` exit.
-        if (httpResponse.statusCode >= 300 || httpResponse.statusCode <= 199) {
-          return exits.non200Response(serverRes);
-        }//•
+      // --•
+      // Otherwise, we'll build a normalized server response.
+      //
+      // > Regardless of the status code sent in the response, we'll
+      // > use this dictionary as our output when we exit below.
+      let serverRes = {
+        statusCode: httpResponse.statusCode,
+        headers: httpResponse.headers || {},
+        body: httpResponse.body || ''
+      };
 
-      } catch (e) { return exits.error(e); }
+      // If the status code of the response is not in the 2xx range, then
+      // return the server response dictionary through the `non2xxResponse` exit.
+      if (httpResponse.statusCode >= 300 || httpResponse.statusCode <= 199) {
+        return exits.non200Response(serverRes);
+      }//•
 
       // Otherwise, IWMIH, return the server response dictionary through
       // the `success` exit.

--- a/lib/send-http-request.js
+++ b/lib/send-http-request.js
@@ -114,9 +114,13 @@ module.exports = {
     // Check for a `content-type` (case-insensitive) header
     if(!_.contains(['GET','HEAD','OPTIONS'], inputs.method) && inputs.headers) {
       for (let headerName in inputs.headers) {
-        // If we found one, and it's anything but 'application-json', freak out.
-        if(headerName.toLowerCase() === 'content-type' && inputs.headers[headerName] !== 'application-json') {
-          throw new Error('Instead of a header for that `content-type`, please pass in an `encType` to `sendHttpRequest`, and the appropriate headers will be set automatically.');
+        // If we found one, and it's one of our
+        if(headerName.toLowerCase() === 'content-type') {
+          let SUPPORTED_ENCTYPES = ['application/json', 'application/x-www-form-urlencoded', 'multipart/form-data'];
+          let contentType = inputs.headers[headerName];
+          if(_.contains(SUPPORTED_ENCTYPES, contentType) && (inputs.enctype !== contentType)) {
+            throw new Error(`Could not determine how to encode data in sendHttpRequest(), because the 'content-type' header does not match the provided \`enctype\` ('${inputs.enctype}').\nTo resolve this, you can do one of the following:\n• Use \`enctype: '${contentType}'\`\n• Set the 'content-type' header to '${inputs.enctype}'`);
+          }
         }
       }
     }

--- a/lib/send-http-request.js
+++ b/lib/send-http-request.js
@@ -116,7 +116,7 @@ module.exports = {
       for (let headerName in inputs.headers) {
         // If we found one, and it's anything but 'application-json', freak out.
         if(headerName.toLowerCase() === 'content-type' && inputs.headers[headerName] !== 'application-json') {
-          throw new Error('Instead of a header for that `content-type`, please speficy an `encType`, and the appropriate headers will be set automatically.');
+          throw new Error('Instead of a header for that `content-type`, please pass in an `encType` to `sendHttpRequest`, and the appropriate headers will be set automatically.');
         }
       }
     }

--- a/lib/send-http-request.js
+++ b/lib/send-http-request.js
@@ -117,9 +117,9 @@ module.exports = {
         // If we found one, and it's one of our
         if(headerName.toLowerCase() === 'content-type') {
           let SUPPORTED_ENCTYPES = ['application/json', 'application/x-www-form-urlencoded', 'multipart/form-data'];
-          let contentType = inputs.headers[headerName];
-          if(_.contains(SUPPORTED_ENCTYPES, contentType) && (inputs.enctype !== contentType)) {
-            throw new Error(`Could not determine how to encode data in sendHttpRequest(), because the 'content-type' header does not match the provided \`enctype\` ('${inputs.enctype}').\nTo resolve this, you can do one of the following:\n• Use \`enctype: '${contentType}'\`\n• Set the 'content-type' header to '${inputs.enctype}'`);
+          let contentTypeHeader = inputs.headers[headerName];
+          if(_.contains(_.reject(SUPPORTED_ENCTYPES, 'application/json'), contentTypeHeader) && (inputs.enctype !== contentTypeHeader)) {
+            throw new Error(`Could not determine how to encode data in sendHttpRequest(), because the 'content-type' header does not match the provided \`enctype\` ('${inputs.enctype}').\nTo resolve this, you can do one of the following:\n• Use \`enctype: '${contentTypeHeader}'\`\n• Set the 'content-type' header to '${inputs.enctype}'`);
           }
         }
       }


### PR DESCRIPTION
If content-type header was included in a scenario where it should be set automatically, throw an error saying to use `encType` instead